### PR TITLE
Reduced Drawing Cycle Time

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -3,11 +3,17 @@ const gridSizeX = 1500;
 const gridSizeY = 1500;
 
 function drawGrid() {
-  background(220);
-  stroke(0);
-  for (let x = 0; x <= gridSizeX; x += spacing) {
-    for (let y = 0; y <= gridSizeY; y += spacing) {
-      point(x, y);
+
+    background(220);
+    stroke("black");
+
+    var ctx = canvas.getContext("2d");
+
+    for (let x = 0; x <= gridSizeX; x += spacing) {
+      for (let y = 0; y <= gridSizeY; y += spacing) {
+
+            point(x, y);
+
+        }
     }
-  }
 }

--- a/Main.js
+++ b/Main.js
@@ -36,26 +36,53 @@
 let state = "SELECT";
 let message = "Main";
 let done = true;
+var dotGrid;
 
 function setup() {
-  let canvas = createCanvas(windowWidth, windowHeight);
-  initZoom();
-  initSources();
-  dropDown(canvas);
+
+    let canvas = createCanvas(windowWidth, windowHeight);
+
+    setupGrid();
+
+    initZoom();
+    initSources();
+    dropDown(canvas);
+
+}
+
+function setupGrid() {
+
+    dotGrid = createGraphics(windowWidth, windowHeight);
+
+    dotGrid.clear();
+
+    dotGrid.stroke("black");
+    dotGrid.fill(255, 0, 0);
+    for (let x = 0; x <= gridSizeX; x += spacing) {
+        for (let y = 0; y <= gridSizeY; y += spacing) {
+
+            dotGrid.point(x, y);
+
+        }
+    }
+
 }
 
 function draw() {
-  //In ZoomAndPan.js
-  translate(offset.x, offset.y);
-  scale(scaling);
 
-  drawGrid();
-  drawControlBoard();
+    //In ZoomAndPan.js
+    translate(offset.x, offset.y);
+    scale(scaling);
 
-  // need to draw first
-  controller();
-  panWithKeys();
-  pan();
+
+    background(220);
+    image(dotGrid, 0, 0);
+    drawControlBoard();
+
+    // need to draw first
+    controller();
+    panWithKeys();
+    pan();
 }
 
 function windowResized() { 


### PR DESCRIPTION
Reduced drawing cycle time by the use of p5 image.

 Previously drawing the grid on each draw cycle inefficiently drew power. The inefficiency causing noticeable CPU load. The power drain was caused by repetitive calls to p5 point function. The reduction of power consumption was made by using p5 image function.

 Drawing cycle time was reduced by generating the grid background image once at startup. The background image later being redrawn at the begging of each draw cycle. Which saved having to repetitively make many calls to p5's point function during each call of the draw method.

 The CPU power consumption by the current drawing method is comparatively about 1/10 it's previous energy drain.